### PR TITLE
Fix linking errors for glib

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,9 +39,15 @@ tar xf ${GLIB_TARBALL}
 cp ${CONFIG_SRC_DIR}/config.sub ${GLIB_SRC_DIR}/config.sub
 cp ${CONFIG_SRC_DIR}/config.guess ${GLIB_SRC_DIR}/config.guess
 
-# Configure and build glib
+# Configure glib
 cd ${GLIB_SRC_DIR}
 ./configure ${GLIB_CONFIGURE_OPTIONS[*]}
+
+# Patch to fix linker issues (multiple definitions)
+# taken from this gist: https://gist.github.com/bbidulock/e7ec7d6622471142e248
+sed 's,ifdef[[:space:]]*__OPTIMIZE__,if 0,' -i glib.h
+
+# Build glib
 make
 make install
 


### PR DESCRIPTION
This patch fixes a linking error found at the building stage of glib, caused by multiple definitions in glib.h